### PR TITLE
Return the intended interface from the constructor function

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,7 +72,7 @@ Then you can connect the debugger through port `30110`.
 
 === Compiling the Protocol
 
-The gRPC protocol for the shell function invoker is defined in https://github.com/projectriff/function-proto/function.proto[function.proto].
+The gRPC protocol for the shell function invoker is defined in https://github.com/projectriff/function-proto/blob/master/function.proto[function.proto].
 
 Clone https://github.com/projectriff/function-proto and set `$FN_PROTO_PATH` to point at the cloned directory. Then issue:
 [source, bash]

--- a/pkg/server/message_function_server.go
+++ b/pkg/server/message_function_server.go
@@ -27,7 +27,7 @@ type messageFunctionServer struct {
 	fnUri string
 }
 
-func New(fnUri string) *messageFunctionServer {
+func New(fnUri string) function.MessageFunctionServer {
 	return &messageFunctionServer{
 		fnUri: fnUri,
 	}


### PR DESCRIPTION
The (pretty weak) counter-arguments are:

* This can be criticised for writing Go like Java.

* Perhaps the constructor function itself is harder to read because the return
  type isn’t obviously implemented by the return value.

The main argument in favour of returning an interface is that the constructor
function then documents a contract: it is intended to return an instance of
a specific, known interface.