### PR TITLE
Disable go modules for installing mockery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(OUTPUT): $(GO_SOURCES)
 	GO111MODULE=on go build cmd/command-function-invoker.go
 
 gen-mocks: $(GO_SOURCES)
-	go get -u github.com/vektra/mockery/.../
+	GO111MODULE=off go get -u github.com/vektra/mockery/.../
 	GO111MODULE=on go generate ./...
 
 clean:


### PR DESCRIPTION
This afternoon, [Travis started](https://changelog.travis-ci.com/go-modules-support-added-for-go-1-11-and-up-88993) to set `GO111MODULES=on` for projects with golang 1.11 and a `go.mod` file. This causes mockery to fail to install. We can get mockery installing again, by turning modules back off for that command.