### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you intend to re-generate mocks for testing, install:
 
 If you would like to run tests using the `ginkgo` command, install:
 
-- [Ginkgo](http://onsi.github.io/ginkgo/)
+- [Ginkgo](https://onsi.github.io/ginkgo/)
 
 ### Building
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://onsi.github.io/ginkgo/ with 1 occurrences migrated to:  
  https://onsi.github.io/ginkgo/ ([https](https://onsi.github.io/ginkgo/) result 200).