### PR TITLE
URL Cleanup

### DIFF
--- a/vendor/github.com/onsi/gomega/matchers/test_data/xml/sample_07.xml
+++ b/vendor/github.com/onsi/gomega/matchers/test_data/xml/sample_07.xml
@@ -1,5 +1,5 @@
 <root>
-    <h:table xmlns:h="http://www.w3.org/TR/html4/">
+    <h:table xmlns:h="https://www.w3.org/TR/html4/">
         <h:tr>
             <h:td>Apples</h:td>
             <h:td>Bananas</h:td>

--- a/vendor/github.com/onsi/gomega/matchers/test_data/xml/sample_08.xml
+++ b/vendor/github.com/onsi/gomega/matchers/test_data/xml/sample_08.xml
@@ -1,5 +1,5 @@
 <root>
-    <h:table xmlns:h="http://www.w3.org/TR/html4/">
+    <h:table xmlns:h="https://www.w3.org/TR/html4/">
         <h:tr>
             <h:td>Apples</h:td>
             <h:td>Oranges</h:td>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/TR/html4/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/html4/ ([https](https://www.w3.org/TR/html4/) result 200).